### PR TITLE
Feature/add joblib backend

### DIFF
--- a/cachesql/serializer.py
+++ b/cachesql/serializer.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+from typing import Union
+
+import joblib
+import pandas as pd
+import pyarrow as pa
+
+
+class BaseSerializer:
+    fmt = ""
+    extension = ""
+
+
+class ParquetSerializer(BaseSerializer):
+
+    fmt = "parquet"
+    extension = ".parquet"
+
+    @classmethod
+    def load(cls, filepath: Union[str, Path]) -> pd.DataFrame:
+        """Load dataframe from parquet file."""
+        return pd.read_parquet(filepath)
+
+    @classmethod
+    def dump(cls, results: pd.DataFrame, filepath: Union[str, Path]) -> None:
+        """Dump dataframe to parquet file."""
+        try:
+            results.to_parquet(filepath)
+        except pa.ArrowInvalid as e:
+            raise ValueError(
+                "It seems that your query is returning a column with a type not "
+                "yet supported by Arrow. Consider using 'joblib' instead: "
+                "Database(uri='...', store_backend='joblib')"
+            )
+
+
+class JoblibSerializer(BaseSerializer):
+
+    fmt = "joblib"
+    extension = ".joblib"
+
+    @classmethod
+    def load(cls, filepath: Union[str, Path]) -> pd.DataFrame:
+        """Load dataframe from file dumped with joblib."""
+        return joblib.load(filepath)
+
+    @classmethod
+    def dump(cls, results: pd.DataFrame, filepath: Union[str, Path]) -> None:
+        """Dump dataframe with joblib."""
+        joblib.dump(results, filepath)

--- a/cachesql/serializer.py
+++ b/cachesql/serializer.py
@@ -23,8 +23,8 @@ class ParquetSerializer(BaseSerializer):
     fmt = "parquet"
     extension = ".parquet"
 
-    def __init__(self, compression="snappy"):
-        self.compression = compression
+    def __init__(self, compression=None):
+        self.compression = compression or "snappy"
 
     @classmethod
     def load(cls, filepath: Union[str, Path]) -> pd.DataFrame:
@@ -56,8 +56,8 @@ class JoblibSerializer(BaseSerializer):
     fmt = "joblib"
     extension = ".joblib"
 
-    def __init__(self, compression=0):
-        self.compression = compression
+    def __init__(self, compression=None):
+        self.compression = compression or 0
 
     @classmethod
     def load(cls, filepath: Union[str, Path]) -> pd.DataFrame:

--- a/cachesql/serializer.py
+++ b/cachesql/serializer.py
@@ -12,6 +12,13 @@ class BaseSerializer:
 
 
 class ParquetSerializer(BaseSerializer):
+    """A serializer of pd.DataFrame to parquet format.
+
+    Parameters
+    ----------
+    compression : {'snappy', 'gzip', 'brotli', None}, default 'snappy'
+        Name of the compression to use. See pd.DataFrame.to_parquet docs
+    """
 
     fmt = "parquet"
     extension = ".parquet"
@@ -37,6 +44,14 @@ class ParquetSerializer(BaseSerializer):
 
 
 class JoblibSerializer(BaseSerializer):
+    """A serializer of pd.DataFrame based on joblib.
+
+    Parameters
+    ----------
+    compression
+        Optional compression level for the data. Passed to parameter
+        'compress' of joblib.dump. See joblib docs
+    """
 
     fmt = "joblib"
     extension = ".joblib"

--- a/cachesql/sql.py
+++ b/cachesql/sql.py
@@ -47,20 +47,12 @@ class Database:
 
         if (cache_store is None) or isinstance(cache_store, (str, Path)):
             cache_store = Path(cache_store or ".cache").absolute() / self.name
-            if store_backend == "parquet":
-                self.cache = store.ParquetStore(
-                    cache_store=Path(cache_store),
-                    normalize=normalize,
-                )
-            elif store_backend == "joblib":
-                self.cache = store.JoblibStore(
-                    cache_store=Path(cache_store),
-                    normalize=normalize,
-                )
-            else:
-                raise ValueError(
-                    f"store_backend={store_backend!r} is invalid. Choose one of {'parquet', 'joblib'}"
-                )
+            self.cache = store.FileStore(
+                cache_store=Path(cache_store),
+                backend=store_backend,
+                normalize=normalize,
+            )
+
         elif isinstance(cache_store, store.BaseStore):
             self.cache = cache_store
 

--- a/cachesql/sql.py
+++ b/cachesql/sql.py
@@ -2,7 +2,7 @@ import logging
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Union
+from typing import Any, Union
 
 import pandas as pd
 from sqlalchemy import create_engine
@@ -32,6 +32,8 @@ class Database:
         determines if it uses 'parquet' or 'joblib as backend
     normalize
         If True, normalize the queries to make the cache independent from formatting changes
+    compression
+        Optional compression parameter to be passed to the serializer.
     """
 
     def __init__(
@@ -41,6 +43,7 @@ class Database:
         cache_store: Union[str, Path, store.BaseStore] = None,
         store_backend: str = "parquet",
         normalize: bool = True,
+        compression: Any = None,
     ):
         self.engine = create_engine(uri)
         self.name = name or self.engine.url.database or "unnameddb"
@@ -51,6 +54,7 @@ class Database:
                 cache_store=Path(cache_store),
                 backend=store_backend,
                 normalize=normalize,
+                compression=compression,
             )
 
         elif isinstance(cache_store, store.BaseStore):

--- a/cachesql/store.py
+++ b/cachesql/store.py
@@ -23,14 +23,15 @@ class BaseStore:
 
 
 class FileStore(BaseStore):
-    """Base class for disk stores.
+    """Flat file store.
 
     Parameters
     ----------
     cache_store
-        Location where the returned values are cached.
+        Root path where the cached files are stored.
     normalize
-        If True, normalize the queries to make the cache independent from formatting changes
+        If True, normalize the queries to make the cache independent from
+        formatting changes. Normalization is done with the sqlparse library.
     """
 
     _serializers = {

--- a/cachesql/store.py
+++ b/cachesql/store.py
@@ -4,10 +4,9 @@ from pathlib import Path
 from typing import Iterable, Tuple, Union
 from zipfile import ZipFile
 
-import joblib
 import pandas as pd
-import pyarrow as pa
 
+from . import serializer
 from .utils import normalize_query
 
 
@@ -34,10 +33,20 @@ class FileStore(BaseStore):
         If True, normalize the queries to make the cache independent from formatting changes
     """
 
-    fmt = ""
+    _serializers = {
+        "parquet": serializer.ParquetSerializer,
+        "joblib": serializer.JoblibSerializer,
+    }
 
-    def __init__(self, cache_store: Path, normalize: bool = False) -> None:
-        self.cache_store = Path(cache_store).expanduser() / self.fmt
+    def __init__(
+        self, cache_store: Path, backend: str = "parquet", normalize: bool = False
+    ) -> None:
+        if backend not in self._serializers:
+            raise ValueError(
+                f"store_backend={backend!r} is invalid. Choose one of {'parquet', 'joblib'}"
+            )
+        self.serializer = self._serializers[backend]
+        self.cache_store = Path(cache_store).expanduser() / self.serializer.fmt
         self.cache_store.mkdir(parents=True, exist_ok=True)
         self.normalize = normalize
 
@@ -54,7 +63,8 @@ class FileStore(BaseStore):
 
     def get_cache_filepath(self, query: str) -> Path:
         """Return the cached results filepath corresponding to that query."""
-        raise NotImplementedError
+        arg_hash = hash_query(query, normalize=self.normalize)
+        return self.cache_store / (arg_hash + self.serializer.extension)
 
     def load_metadata(self, query: str) -> dict:
         """Load metadata of cached results for query if it exists in cache."""
@@ -66,7 +76,11 @@ class FileStore(BaseStore):
 
     def load_results(self, query: str) -> pd.DataFrame:
         """Load cached results for query if it exists in cache."""
-        raise NotImplementedError
+        cache_file = self.get_cache_filepath(query)
+        if cache_file.exists():
+            return self.serializer.load(cache_file)
+        else:
+            raise ValueError("Cached results for the given query do not exist.")
 
     def load(self, query: str) -> Tuple[pd.DataFrame, dict]:
         """Load results and metadata for a query if they exist in cache."""
@@ -81,7 +95,8 @@ class FileStore(BaseStore):
 
     def dump_results(self, query: str, results: pd.DataFrame) -> None:
         """Dump query results to cache."""
-        raise NotImplementedError
+        cache_file = self.get_cache_filepath(query)
+        self.serializer.dump(results, cache_file)
 
     def dump(self, query: str, results: pd.DataFrame, metadata: dict) -> None:
         """Dump results and metadata for given query to cache."""
@@ -147,74 +162,3 @@ class FileStore(BaseStore):
         """
         with ZipFile(filename, "r") as myzip:
             myzip.extractall(path=self.cache_store)
-
-
-class ParquetStore(FileStore):
-    """Disk store based on parquet files.
-
-    Parameters
-    ----------
-    cache_store
-        Location where the returned values are cached.
-    normalize
-        If True, normalize the queries to make the cache independent from formatting changes
-    """
-
-    fmt = "parquet"
-
-    def get_cache_filepath(self, query: str) -> Path:
-        """Return the cached results filepath corresponding to that query."""
-        arg_hash = hash_query(query, normalize=self.normalize)
-        return self.cache_store / (arg_hash + ".parquet")
-
-    def load_results(self, query: str) -> pd.DataFrame:
-        """Load cached results for query if it exists in cache."""
-        cache_file = self.get_cache_filepath(query)
-        if cache_file.exists():
-            return pd.read_parquet(cache_file)
-        else:
-            raise ValueError("Cached results for the given query do not exist.")
-
-    def dump_results(self, query: str, results: pd.DataFrame) -> None:
-        """Dump query results to cache."""
-        cache_file = self.get_cache_filepath(query)
-        try:
-            results.to_parquet(cache_file)
-        except pa.ArrowInvalid as e:
-            raise ValueError(
-                "It seems that your query is returning a column with a type not "
-                "yet supported by Arrow. Consider using 'joblib' instead: "
-                "Database(uri='...', store_backend='joblib')"
-            )
-
-
-class JoblibStore(FileStore):
-    """Disk store based on joblib.
-
-    Parameters
-    ----------
-    cache_store
-        Location where the returned values are cached.
-    normalize
-        If True, normalize the queries to make the cache independent from formatting changes
-    """
-
-    fmt = "joblib"
-
-    def get_cache_filepath(self, query: str) -> Path:
-        """Return the cached results filepath corresponding to that query."""
-        arg_hash = hash_query(query, normalize=self.normalize)
-        return self.cache_store / (arg_hash + ".joblib")
-
-    def load_results(self, query: str) -> pd.DataFrame:
-        """Load cached results for query if it exists in cache."""
-        cache_file = self.get_cache_filepath(query)
-        if cache_file.exists():
-            return joblib.load(cache_file)
-        else:
-            raise ValueError("Cached results for the given query do not exist.")
-
-    def dump_results(self, query: str, results: pd.DataFrame) -> None:
-        """Dump query results to cache."""
-        cache_file = self.get_cache_filepath(query)
-        joblib.dump(results, cache_file)

--- a/cachesql/store.py
+++ b/cachesql/store.py
@@ -1,7 +1,7 @@
 import hashlib
 import json
 from pathlib import Path
-from typing import Iterable, Tuple, Union
+from typing import Any, Iterable, Tuple, Union
 from zipfile import ZipFile
 
 import pandas as pd
@@ -32,6 +32,9 @@ class FileStore(BaseStore):
     normalize
         If True, normalize the queries to make the cache independent from
         formatting changes. Normalization is done with the sqlparse library.
+    compression
+        Optional compression parameter to be passed to the serializer.
+
     """
 
     _serializers = {
@@ -40,13 +43,17 @@ class FileStore(BaseStore):
     }
 
     def __init__(
-        self, cache_store: Path, backend: str = "parquet", normalize: bool = False
+        self,
+        cache_store: Path,
+        backend: str = "parquet",
+        normalize: bool = False,
+        compression: Any = None,
     ) -> None:
         if backend not in self._serializers:
             raise ValueError(
                 f"store_backend={backend!r} is invalid. Choose one of {'parquet', 'joblib'}"
             )
-        self.serializer = self._serializers[backend]()
+        self.serializer = self._serializers[backend](compression=compression)
         self.cache_store = Path(cache_store).expanduser() / self.serializer.fmt
         self.cache_store.mkdir(parents=True, exist_ok=True)
         self.normalize = normalize

--- a/cachesql/store.py
+++ b/cachesql/store.py
@@ -45,7 +45,7 @@ class FileStore(BaseStore):
             raise ValueError(
                 f"store_backend={backend!r} is invalid. Choose one of {'parquet', 'joblib'}"
             )
-        self.serializer = self._serializers[backend]
+        self.serializer = self._serializers[backend]()
         self.cache_store = Path(cache_store).expanduser() / self.serializer.fmt
         self.cache_store.mkdir(parents=True, exist_ok=True)
         self.normalize = normalize

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ pandas = "^1.0.0"
 sqlalchemy = "^1.3.22"
 pyarrow = "^2.0.0"
 sqlparse = "^0.4.1"
+joblib = "^1.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,3 +42,13 @@ def results():
 @pytest.fixture
 def parquet_store(tmp_path):
     return store.ParquetStore(cache_store=tmp_path, normalize=True)
+
+
+@pytest.fixture
+def joblib_store(tmp_path):
+    return store.JoblibStore(cache_store=tmp_path, normalize=True)
+
+
+@pytest.fixture
+def file_store(tmp_path):
+    return store.FileStore(cache_store=tmp_path, normalize=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,15 +40,5 @@ def results():
 
 
 @pytest.fixture
-def parquet_store(tmp_path):
-    return store.ParquetStore(cache_store=tmp_path, normalize=True)
-
-
-@pytest.fixture
-def joblib_store(tmp_path):
-    return store.JoblibStore(cache_store=tmp_path, normalize=True)
-
-
-@pytest.fixture
 def file_store(tmp_path):
     return store.FileStore(cache_store=tmp_path, normalize=True)

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -7,6 +7,10 @@ from cachesql import serializer
 
 
 class TestParquetSerializer:
+    def test_init_compression_is_none(self):
+        s = serializer.ParquetSerializer()
+        assert s.compression == "snappy"
+
     def test_dump_load_results(self, tmp_path, results):
         s = serializer.ParquetSerializer()
         s.dump(results, tmp_path / "file.parquet")
@@ -23,6 +27,10 @@ class TestParquetSerializer:
 
 
 class TestJoblibSerializer:
+    def test_init_compression_is_none(self):
+        s = serializer.JoblibSerializer()
+        assert s.compression == 0
+
     def test_dump_load_results(self, tmp_path, results):
         s = serializer.JoblibSerializer()
         s.dump(results, tmp_path / "file.parquet")

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,0 +1,31 @@
+from uuid import uuid1
+
+import pandas as pd
+import pytest
+
+from cachesql import serializer
+
+
+class TestParquetSerializer:
+    def test_dump_load_results(self, tmp_path, results):
+        s = serializer.ParquetSerializer
+        s.dump(results, tmp_path / "file.parquet")
+        assert (tmp_path / "file.parquet").exists()
+        results_loaded = s.load(tmp_path / "file.parquet")
+        assert results.equals(results_loaded)
+
+    def test_invalid_arrow_type(self, tmp_path):
+        s = serializer.ParquetSerializer
+        results = pd.Series([uuid1() for i in range(3)], name="uuid_col").to_frame()
+        with pytest.raises(ValueError) as excinfo:
+            s.dump(results, tmp_path / "file.parquet")
+        assert "Database(uri='...', store_backend='joblib')" in str(excinfo.value)
+
+
+class TestJoblibSerializer:
+    def test_dump_load_results(self, tmp_path, results):
+        s = serializer.JoblibSerializer
+        s.dump(results, tmp_path / "file.parquet")
+        assert (tmp_path / "file.parquet").exists()
+        results_loaded = s.load(tmp_path / "file.parquet")
+        assert results.equals(results_loaded)

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -8,14 +8,14 @@ from cachesql import serializer
 
 class TestParquetSerializer:
     def test_dump_load_results(self, tmp_path, results):
-        s = serializer.ParquetSerializer
+        s = serializer.ParquetSerializer()
         s.dump(results, tmp_path / "file.parquet")
         assert (tmp_path / "file.parquet").exists()
         results_loaded = s.load(tmp_path / "file.parquet")
         assert results.equals(results_loaded)
 
     def test_invalid_arrow_type(self, tmp_path):
-        s = serializer.ParquetSerializer
+        s = serializer.ParquetSerializer()
         results = pd.Series([uuid1() for i in range(3)], name="uuid_col").to_frame()
         with pytest.raises(ValueError) as excinfo:
             s.dump(results, tmp_path / "file.parquet")
@@ -24,7 +24,7 @@ class TestParquetSerializer:
 
 class TestJoblibSerializer:
     def test_dump_load_results(self, tmp_path, results):
-        s = serializer.JoblibSerializer
+        s = serializer.JoblibSerializer()
         s.dump(results, tmp_path / "file.parquet")
         assert (tmp_path / "file.parquet").exists()
         results_loaded = s.load(tmp_path / "file.parquet")

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -64,6 +64,7 @@ class TestDBConnector:
             == tmp_path / ".cache" / "none_as_cache" / db.cache.serializer.fmt
         )
         assert isinstance(db.cache.serializer, serializer.ParquetSerializer)
+        assert db.cache.serializer.compression == "snappy"
         os.chdir(previous_wd)
 
     def test_instantiate_with_store_backend_joblib(self, mock_read_sql, tmp_path):
@@ -81,6 +82,7 @@ class TestDBConnector:
             == tmp_path / ".cache" / "store_backend_joblib" / db.cache.serializer.fmt
         )
         assert isinstance(db.cache.serializer, serializer.JoblibSerializer)
+        assert db.cache.serializer.compression == 0
         os.chdir(previous_wd)
 
     def test_instantiate_with_store_backend_wrong(self, mock_read_sql, tmp_path):

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -37,7 +37,7 @@ class TestDBConnector:
         assert (
             db.cache.cache_store == Path("/tmp/str_as_cache") / db.cache.serializer.fmt
         )
-        assert db.cache.serializer == serializer.ParquetSerializer
+        assert isinstance(db.cache.serializer, serializer.ParquetSerializer)
 
     def test_instantiate_with_cache_store_as_path(self, mock_read_sql, tmp_path):
         db = sql.Database(
@@ -48,7 +48,7 @@ class TestDBConnector:
         assert (
             db.cache.cache_store == tmp_path / "path_as_cache" / db.cache.serializer.fmt
         )
-        assert db.cache.serializer == serializer.ParquetSerializer
+        assert isinstance(db.cache.serializer, serializer.ParquetSerializer)
 
     def test_instantiate_with_cache_store_as_none(self, mock_read_sql, tmp_path):
         previous_wd = os.getcwd()
@@ -63,7 +63,7 @@ class TestDBConnector:
             db.cache.cache_store
             == tmp_path / ".cache" / "none_as_cache" / db.cache.serializer.fmt
         )
-        assert db.cache.serializer == serializer.ParquetSerializer
+        assert isinstance(db.cache.serializer, serializer.ParquetSerializer)
         os.chdir(previous_wd)
 
     def test_instantiate_with_store_backend_joblib(self, mock_read_sql, tmp_path):
@@ -80,7 +80,7 @@ class TestDBConnector:
             db.cache.cache_store
             == tmp_path / ".cache" / "store_backend_joblib" / db.cache.serializer.fmt
         )
-        assert db.cache.serializer == serializer.JoblibSerializer
+        assert isinstance(db.cache.serializer, serializer.JoblibSerializer)
         os.chdir(previous_wd)
 
     def test_instantiate_with_store_backend_wrong(self, mock_read_sql, tmp_path):
@@ -105,7 +105,7 @@ class TestDBConnector:
         )
         assert db.cache == parquet_store
         assert db.cache.cache_store == tmp_path / db.cache.serializer.fmt
-        assert db.cache.serializer == serializer.ParquetSerializer
+        assert isinstance(db.cache.serializer, serializer.ParquetSerializer)
 
     def test_instantiate_with_cache_store_as_joblib_store(
         self, mock_read_sql, tmp_path
@@ -118,7 +118,7 @@ class TestDBConnector:
         )
         assert db.cache == joblib_store
         assert db.cache.cache_store == tmp_path / db.cache.serializer.fmt
-        assert db.cache.serializer == serializer.JoblibSerializer
+        assert isinstance(db.cache.serializer, serializer.JoblibSerializer)
 
     def test_load_results_from_cache(self, mock_read_sql, db, query):
         """Test the cache fetches results from cache on a second call"""

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -3,7 +3,7 @@ from uuid import uuid1
 import pandas as pd
 import pytest
 
-from cachesql import store, utils, serializer
+from cachesql import serializer, store, utils
 
 
 class TestFileStore:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -3,12 +3,24 @@ from uuid import uuid1
 import pandas as pd
 import pytest
 
-from cachesql import store, utils
+from cachesql import store, utils, serializer
 
 
 class TestFileStore:
     def test_init(self, tmp_path):
         s = store.FileStore(cache_store=tmp_path)
+        assert s.cache_store.exists()
+
+    def test_init_parquet(self, tmp_path):
+        s = store.FileStore(cache_store=tmp_path, backend="parquet")
+        assert isinstance(s.serializer, serializer.ParquetSerializer)
+        s.serializer.compression == "snappy"
+        assert s.cache_store.exists()
+
+    def test_init_joblib(self, tmp_path):
+        s = store.FileStore(cache_store=tmp_path, backend="joblib")
+        assert isinstance(s.serializer, serializer.JoblibSerializer)
+        s.serializer.compression == 0
         assert s.cache_store.exists()
 
     def test_get_filepaths_parquet(self, tmp_path, query):


### PR DESCRIPTION
This pull request opens the possibility of changing the file serializer between parquet and joblib. It also makes it easier to add new serializers in the future, e.g., a CSV, json or excel serializer. Although I think joblib and parquet cover most cases I am able to imagine at the moment.

The motiviation for this comes from issue #1, where the user reports that the parquet format does not support UUID type. This is solved by using the joblib backend instead.

Personally, I prefer parquet to remain the default as it is faster and lighter, although I realize now that joblib can cover more use cases. This is something to be reconsidered in the future

The backend can be changed when instantiating the `Database`:

```python
from cachesql import Database
db = Database(uri="...", store_backend="joblib")
```


closses #1 